### PR TITLE
watch-ingress-endpoints

### DIFF
--- a/helm/ingress-exporter-chart/templates/configmap.yaml
+++ b/helm/ingress-exporter-chart/templates/configmap.yaml
@@ -11,5 +11,6 @@ data:
           server: true
       listen:
         address: 'http://0.0.0.0:8000'
-    kubernetes:
-      incluster: true
+    service:
+      kubernetes:
+        incluster: true

--- a/helm/ingress-exporter-chart/templates/configmap.yaml
+++ b/helm/ingress-exporter-chart/templates/configmap.yaml
@@ -11,5 +11,5 @@ data:
           server: true
       listen:
         address: 'http://0.0.0.0:8000'
-      kubernetes:
-        incluster: true
+    kubernetes:
+      incluster: true

--- a/helm/ingress-exporter-chart/templates/deployment.yaml
+++ b/helm/ingress-exporter-chart/templates/deployment.yaml
@@ -53,5 +53,6 @@ spec:
         ports:
           - name: http
             containerPort: 8000
+      serviceAccountName: ingress-exporter
       imagePullSecrets:
       - name: ingress-exporter-pull-secret

--- a/helm/ingress-exporter-chart/templates/rbac.yaml
+++ b/helm/ingress-exporter-chart/templates/rbac.yaml
@@ -1,0 +1,34 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ingress-exporter
+rules:
+  - apiGroups:
+      - provider.giantswarm.io
+    resources:
+      - awsconfigs
+      - kvmconfigs
+      - azureconfigs
+    verbs:
+      - "get"
+      - "list"
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+    verbs:
+      - get
+      - "list"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ingress-exporter
+subjects:
+  - kind: ServiceAccount
+    name: ingress-exporter
+    namespace: monitoring
+roleRef:
+  kind: ClusterRole
+  name: ingress-exporter
+  apiGroup: rbac.authorization.k8s.io

--- a/helm/ingress-exporter-chart/templates/rbac.yaml
+++ b/helm/ingress-exporter-chart/templates/rbac.yaml
@@ -6,9 +6,7 @@ rules:
   - apiGroups:
       - provider.giantswarm.io
     resources:
-      - awsconfigs
       - kvmconfigs
-      - azureconfigs
     verbs:
       - "get"
       - "list"

--- a/helm/ingress-exporter-chart/templates/serviceaccount.yaml
+++ b/helm/ingress-exporter-chart/templates/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ingress-exporter
+  namespace: monitoring

--- a/service/collector/collector.go
+++ b/service/collector/collector.go
@@ -22,7 +22,7 @@ const (
 	maxIdleConnection = 5
 	maxTimeoutSec     = 5
 
-	ingressCheckSucesfull = 1
+	ingressCheckSuccessful = 1
 	ingressCheckFailure   = 0
 
 	ingresSchemeHttp   = "http"

--- a/service/collector/collector.go
+++ b/service/collector/collector.go
@@ -22,6 +22,9 @@ const (
 	maxIdleConnection = 50
 	maxTimeoutSec     = 5
 
+	ingressCheckSucesfull = 1
+	ingressCheckFailure   = 0
+
 	ingresSchemeHttp   = "http"
 	ingressSchemeHttps = "https"
 

--- a/service/collector/collector.go
+++ b/service/collector/collector.go
@@ -19,7 +19,7 @@ const (
 )
 
 const (
-	maxIdleConnection = 50
+	maxIdleConnection = 5
 	maxTimeoutSec     = 5
 
 	ingressCheckSucesfull = 1
@@ -30,4 +30,8 @@ const (
 
 	ingressPortHttp  = 30010
 	ingressPortHttps = 30011
+
+	proxyProtocolTrue    = "true"
+	proxyProtocolFalse   = "false"
+	proxyProtocolUnknown = "unknown"
 )

--- a/service/collector/collector.go
+++ b/service/collector/collector.go
@@ -25,7 +25,7 @@ const (
 	ingressCheckSuccessful = 1
 	ingressCheckFailure   = 0
 
-	ingresSchemeHttp   = "http"
+	ingressSchemeHttp   = "http"
 	ingressSchemeHttps = "https"
 
 	ingressPortHttp  = 30010

--- a/service/collector/collector.go
+++ b/service/collector/collector.go
@@ -11,3 +11,20 @@ const (
 	labelProtocol      = "protocol"
 	labelProxyProtocol = "proxy_protocol"
 )
+
+const (
+	crdNamespace   = "default"
+	workerEndpoint = "worker"
+	masterEndpoint = "master"
+)
+
+const (
+	maxIdleConnection = 50
+	maxTimeoutSec     = 5
+
+	ingresSchemeHttp = "http"
+	ingressSchemeHttps = "https"
+
+	ingressPortHttp = 30010
+	ingressPortHttps = 30011
+)

--- a/service/collector/collector.go
+++ b/service/collector/collector.go
@@ -22,9 +22,9 @@ const (
 	maxIdleConnection = 50
 	maxTimeoutSec     = 5
 
-	ingresSchemeHttp = "http"
+	ingresSchemeHttp   = "http"
 	ingressSchemeHttps = "https"
 
-	ingressPortHttp = 30010
+	ingressPortHttp  = 30010
 	ingressPortHttps = 30011
 )

--- a/service/collector/collector.go
+++ b/service/collector/collector.go
@@ -23,9 +23,9 @@ const (
 	maxTimeoutSec     = 5
 
 	ingressCheckSuccessful = 1
-	ingressCheckFailure   = 0
+	ingressCheckFailure    = 0
 
-	ingressSchemeHttp   = "http"
+	ingressSchemeHttp  = "http"
 	ingressSchemeHttps = "https"
 
 	ingressPortHttp  = 30010

--- a/service/collector/endpoint.go
+++ b/service/collector/endpoint.go
@@ -187,10 +187,9 @@ func (e *Endpoint) ingressEndpointUp(ipAddress string, scheme string, port int) 
 	if err == nil {
 		// ingress endpoint check was successful, proxy-protocol enabled
 		return ingressCheckSucesfull, proxyProtocolTrue
-	} else {
-		// ingress endpoint check failure
-		return ingressCheckFailure, proxyProtocolUnknown
 	}
+	// ingress endpoint check failure
+	return ingressCheckFailure, proxyProtocolUnknown
 }
 
 // ingressEndpointUpClassicHttp send http packet to the endpoint to ensure target ingress endpoint ip is up
@@ -204,11 +203,12 @@ func (e *Endpoint) ingressEndpointUpClassicHttp(ipAddress string, scheme string,
 	defer e.httpTransport.CloseIdleConnections()
 
 	// send request to http endpoint
-	_, err = e.httpClient.Do(req)
+	resp, err := e.httpClient.Do(req)
 	if err != nil {
 		// ingress endpoint failed to respond properly
 		return microerror.Mask(err)
 	}
+	defer resp.Body.Close()
 
 	return nil
 }

--- a/service/collector/endpoint.go
+++ b/service/collector/endpoint.go
@@ -233,9 +233,8 @@ func (e *Endpoint) ingressEndpointUpProxyProtocol(ipAddress string, scheme strin
 	}
 
 	// open tcp connection to ingress endpoint
-	conn, err := net.Dial("tcp", fmt.Sprintf("%s:%d", ipAddress, port))
+	conn, err := net.DialTimeout("tcp", fmt.Sprintf("%s:%d", ipAddress, port), maxTimeoutSec*time.Second)
 	if err != nil {
-		// handle error
 		return microerror.Mask(err)
 	}
 	defer conn.Close()
@@ -243,14 +242,12 @@ func (e *Endpoint) ingressEndpointUpProxyProtocol(ipAddress string, scheme strin
 	// write buffer to connection
 	_, err = buffer.WriteTo(conn)
 	if err != nil {
-		// handle error
 		return microerror.Mask(err)
 	}
 
 	// read http response from connection
 	_, err = http.ReadResponse(bufio.NewReader(conn), req)
 	if err != nil {
-		// handle error
 		return microerror.Mask(err)
 	}
 

--- a/service/collector/endpoint.go
+++ b/service/collector/endpoint.go
@@ -178,7 +178,7 @@ func (e *Endpoint) ingressEndpointUp(ipAddress string, scheme string, port int) 
 
 	if err == nil {
 		// ingress endpoint check was successful, no proxy-protocol
-		return ingressCheckSucesfull, proxyProtocolFalse
+		return ingressCheckSuccessful, proxyProtocolFalse
 
 	}
 	// ingress endpoint check error, but we might just hit proxy protocol so try check with proxy-protocol enabled

--- a/service/collector/endpoint.go
+++ b/service/collector/endpoint.go
@@ -181,7 +181,7 @@ func (e *Endpoint) ingressEndpointUp(ipAddress string, scheme string, port int) 
 		return ingressCheckSuccessful, proxyProtocolFalse
 	}
 	// ingress endpoint check error, but we might just hit proxy protocol so try check with proxy-protocol enabled
-	err = e.ingressEndpointUpProxyProtocol(ipAddress, ingresSchemeHttp, ingressPortHttp)
+	err = e.ingressEndpointUpProxyProtocol(ipAddress, ingressSchemeHttp, ingressPortHttp)
 
 	if err == nil {
 		// ingress endpoint check was successful, proxy-protocol enabled

--- a/service/collector/endpoint.go
+++ b/service/collector/endpoint.go
@@ -88,7 +88,7 @@ func (e *Endpoint) Collect(ch chan<- prometheus.Metric) error {
 	listOpts := metav1.ListOptions{}
 	getOpts := metav1.GetOptions{}
 
-	kvmConfigs, err := e.g8sClient.CoreV1alpha1().KVMClusterConfigs(crdNamespace).List(listOpts)
+	kvmConfigs, err := e.g8sClient.ProviderV1alpha1().KVMConfigs(crdNamespace).List(listOpts)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/service/collector/endpoint.go
+++ b/service/collector/endpoint.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"crypto/tls"
 	"fmt"
-	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -111,16 +110,13 @@ func (e *Endpoint) Collect(ch chan<- prometheus.Metric) error {
 			err := e.ingressEndpointUpClassicHttp(ip, ingresSchemeHttp, ingressPortHttp)
 
 			// io.EOF error can be indicator of enabled proxy-protocol
-			if err == io.EOF {
-				fmt.Printf("EOF error, possibly proxy protocol enabled\n")
+			if err != nil {
 				err := e.ingressEndpointUpProxyProtocol(ip, ingresSchemeHttp, ingressPortHttp)
 				if err != nil {
 					fmt.Printf("proxy protocol http error: %s\n", err)
 					return microerror.Mask(err)
 				}
 				// ingress check failed
-			} else if err != nil {
-				return microerror.Mask(err)
 			}
 		}
 	}

--- a/service/collector/endpoint.go
+++ b/service/collector/endpoint.go
@@ -22,7 +22,7 @@ import (
 
 var (
 	endpointLabelsDesc *prometheus.Desc = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, subsystem, "avaiable"),
+		prometheus.BuildFQName(namespace, subsystem, "available"),
 		"Availability of ingress controller on ingress endpoint ip.",
 		[]string{
 			labelClusterID,

--- a/service/collector/endpoint.go
+++ b/service/collector/endpoint.go
@@ -186,7 +186,7 @@ func (e *Endpoint) ingressEndpointUp(ipAddress string, scheme string, port int) 
 
 	if err == nil {
 		// ingress endpoint check was successful, proxy-protocol enabled
-		return ingressCheckSucesfull, proxyProtocolTrue
+		return ingressCheckSuccessful, proxyProtocolTrue
 	} else {
 		// ingress endpoint check failure
 		return ingressCheckFailure, proxyProtocolUnknown

--- a/service/collector/endpoint.go
+++ b/service/collector/endpoint.go
@@ -1,10 +1,20 @@
 package collector
 
 import (
+	"bufio"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"time"
+
 	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"github.com/prometheus/client_golang/prometheus"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -29,9 +39,12 @@ type EndpointConfig struct {
 }
 
 type Endpoint struct {
-	g8sClient *versioned.Clientset
-	k8sClient kubernetes.Interface
-	logger    micrologger.Logger
+	g8sClient     *versioned.Clientset
+	httpClient    *http.Client
+	httpTransport *http.Transport
+	k8sClient     kubernetes.Interface
+	localIP       string
+	logger        micrologger.Logger
 
 	customLabels []string
 }
@@ -47,23 +60,182 @@ func NewEndpoint(config EndpointConfig) (*Endpoint, error) {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
 	}
 
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		MaxIdleConns:    maxIdleConnection,
+	}
+
+	client := &http.Client{
+		Transport: tr,
+		Timeout:   maxTimeoutSec * time.Second,
+	}
+
 	i := &Endpoint{
-		g8sClient: config.G8sClient,
-		k8sClient: config.K8sClient,
-		logger:    config.Logger,
+		g8sClient:     config.G8sClient,
+		httpClient:    client,
+		httpTransport: tr,
+		k8sClient:     config.K8sClient,
+		localIP:       getLocalIP(),
+		logger:        config.Logger,
 	}
 
 	return i, nil
 }
 
-func (i *Endpoint) Collect(ch chan<- prometheus.Metric) error {
+func (e *Endpoint) Collect(ch chan<- prometheus.Metric) error {
 	// TODO
 	// Here we will put implementation of collecting data for each endpoint IP
+	listOpts := metav1.ListOptions{}
+	getOpts := metav1.GetOptions{}
+
+	kvmConfigs, err := e.g8sClient.CoreV1alpha1().KVMClusterConfigs(crdNamespace).List(listOpts)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	for _, kvmConfig := range kvmConfigs.Items {
+		if kvmConfig.DeletionTimestamp != nil {
+			// ignore clusters that are marked for deletion
+			continue
+		}
+
+		endpoint, err := e.k8sClient.CoreV1().Endpoints(kvmConfig.Name).Get(workerEndpoint, getOpts)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		ipList := getEndpointIps(endpoint)
+		for _, ip := range ipList {
+			err := e.ingressEndpointUpClassicHttp(ip, ingresSchemeHttp, ingressPortHttp)
+			if err != nil {
+				fmt.Printf("classic http error: %s\n", err)
+
+				err := e.ingressEndpointUpProxyProtocol(ip, ingresSchemeHttp, ingressPortHttp)
+				if err != nil {
+					fmt.Printf("proxy protocol http error: %s\n", err)
+				}
+			}
+		}
+	}
 
 	return nil
 }
 
-func (i *Endpoint) Describe(ch chan<- *prometheus.Desc) error {
+func (e *Endpoint) Describe(ch chan<- *prometheus.Desc) error {
 	ch <- endpointLabelsDesc
 	return nil
+}
+
+func getEndpointIps(endpoint *corev1.Endpoints) []string {
+	var ipList []string
+	for _, subset := range endpoint.Subsets {
+		for _, address := range subset.Addresses {
+			ipList = append(ipList, address.IP)
+		}
+	}
+
+	return ipList
+}
+
+func (e *Endpoint) buildHttpRequest(ipAddress string, scheme string, port int) (*http.Request, error) {
+	u := url.URL{
+		Host:   fmt.Sprintf("%s:%d", ipAddress, port),
+		Path:   "healthz",
+		Scheme: scheme,
+	}
+
+	// be sure to close idle connection after health check is finished
+	defer e.httpTransport.CloseIdleConnections()
+
+	req, err := http.NewRequest("GET", u.String(), nil)
+	if err != nil {
+		return nil, microerror.Maskf(err, "unable to construct health check request")
+	}
+
+	// close connection after health check request (the TCP connection gets
+	// closed by deferred s.tr.CloseIdleConnections()).
+	req.Header.Add("Connection", "close")
+
+	return req, nil
+}
+
+// ingressEndpointUpClassicHttp send http packet to the endpoint to ensure target ingress endpoint ip is up
+func (e *Endpoint) ingressEndpointUpClassicHttp(ipAddress string, scheme string, port int) error {
+	req, err := e.buildHttpRequest(ipAddress, scheme, port)
+	if err != nil {
+		// failed to build http req
+		return microerror.Mask(err)
+	}
+
+	// send request to http endpoint
+	response, err := e.httpClient.Do(req)
+	if err != nil {
+		// ingress endpoint failed to respond properly
+		return microerror.Mask(err)
+	}
+	fmt.Printf("classic http response status %s", response.Status)
+
+	return nil
+}
+
+// ingressEndpointUpProxyProtocol send encapsulated http packet into proxy-protocol to the endpoint to ensure target ingress endpoint ip is up
+func (e *Endpoint) ingressEndpointUpProxyProtocol(ipAddress string, scheme string, port int) error {
+	var buffer bufio.ReadWriter
+	// build http request
+	req, err := e.buildHttpRequest(ipAddress, scheme, port)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	// write proxy-protocol header to buffer
+	_, err = fmt.Fprintf(buffer, "PROXY TCP4 %s %s 80 80\r\n", e.localIP, e.localIP)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	// write http request to buffer
+	err = req.Write(buffer)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	// open tcp connection to ingress endpoint
+	conn, err := net.Dial("tcp", fmt.Sprintf("%s:%d", ipAddress, port))
+	if err != nil {
+		// handle error
+		return microerror.Mask(err)
+	}
+	defer conn.Close()
+
+	// write buffer to connection
+	_, err = buffer.WriteTo(conn)
+	if err != nil {
+		// handle error
+		return microerror.Mask(err)
+	}
+
+	// read http response from connection
+	response, err := http.ReadResponse(bufio.NewReader(conn), req)
+	if err != nil {
+		// handle error
+		return microerror.Mask(err)
+	}
+	fmt.Printf("proxy protocol response status %s", response.Status)
+
+	return nil
+}
+
+// getLocalIP returns the non loopback local IP of the host.
+func getLocalIP() string {
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		return ""
+	}
+	for _, address := range addrs {
+		// check the address type and if it is not a loopback the display it
+		if ipnet, ok := address.(*net.IPNet); ok && !ipnet.IP.IsLoopback() {
+			if ipnet.IP.To4() != nil {
+				return ipnet.IP.String()
+			}
+		}
+	}
+	return ""
 }

--- a/service/collector/endpoint.go
+++ b/service/collector/endpoint.go
@@ -179,7 +179,6 @@ func (e *Endpoint) ingressEndpointUp(ipAddress string, scheme string, port int) 
 	if err == nil {
 		// ingress endpoint check was successful, no proxy-protocol
 		return ingressCheckSuccessful, proxyProtocolFalse
-
 	}
 	// ingress endpoint check error, but we might just hit proxy protocol so try check with proxy-protocol enabled
 	err = e.ingressEndpointUpProxyProtocol(ipAddress, ingresSchemeHttp, ingressPortHttp)

--- a/service/collector/endpoint.go
+++ b/service/collector/endpoint.go
@@ -176,7 +176,7 @@ func getEndpointIps(endpoint *corev1.Endpoints) []string {
 func (e *Endpoint) buildHttpRequest(ipAddress string, scheme string, port int) (*http.Request, error) {
 	u := url.URL{
 		Host:   fmt.Sprintf("%s:%d", ipAddress, port),
-		Path:   "", //healthz
+		Path:   "healthz",
 		Scheme: scheme,
 	}
 
@@ -204,12 +204,11 @@ func (e *Endpoint) ingressEndpointUpClassicHttp(ipAddress string, scheme string,
 	}
 
 	// send request to http endpoint
-	response, err := e.httpClient.Do(req)
+	_, err = e.httpClient.Do(req)
 	if err != nil {
 		// ingress endpoint failed to respond properly
 		return microerror.Mask(err)
 	}
-	fmt.Printf("classic http response status %s\n", response.Status)
 
 	return nil
 }
@@ -249,12 +248,11 @@ func (e *Endpoint) ingressEndpointUpProxyProtocol(ipAddress string, scheme strin
 	}
 
 	// read http response from connection
-	response, err := http.ReadResponse(bufio.NewReader(conn), req)
+	_, err = http.ReadResponse(bufio.NewReader(conn), req)
 	if err != nil {
 		// handle error
 		return microerror.Mask(err)
 	}
-	fmt.Printf("proxy protocol response status %s\n", response.Status)
 
 	return nil
 }

--- a/service/collector/endpoint.go
+++ b/service/collector/endpoint.go
@@ -121,7 +121,7 @@ func (e *Endpoint) Collect(ch chan<- prometheus.Metric) error {
 					ingressCheckState,
 					clusterID,
 					ip,
-					ingresSchemeHttp,
+					ingressSchemeHttp,
 					proxyProtocol,
 				)
 			}

--- a/service/collector/endpoint.go
+++ b/service/collector/endpoint.go
@@ -112,7 +112,7 @@ func (e *Endpoint) Collect(ch chan<- prometheus.Metric) error {
 
 			ipList := getEndpointIps(endpoint)
 			for _, ip := range ipList {
-				ingressCheckState, proxyProtocol := e.ingressEndpointUp(ip, ingresSchemeHttp, ingressPortHttp)
+				ingressCheckState, proxyProtocol := e.ingressEndpointUp(ip, ingressSchemeHttp, ingressPortHttp)
 
 				// send ingress endpoint status metric
 				ch <- prometheus.MustNewConstMetric(


### PR DESCRIPTION
the implementation fo watching ingress endpoints for the ingress-exporter
support cluster with proxy-protocol enabled and disabled

part of implementation taken from `k8s-kvm-health` http probe
The proxy protocol header definition is taken from haproxy documentation

tested on gorgoth, seems to work fine


for https://github.com/giantswarm/giantswarm/issues/5199