### PR TITLE
Update rbac.yaml

### DIFF
--- a/helm/ingress-exporter/templates/rbac.yaml
+++ b/helm/ingress-exporter/templates/rbac.yaml
@@ -35,7 +35,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ .Values.name }}-psp
-  rules:
+rules:
   - apiGroups:
       - extensions
     resources:


### PR DESCRIPTION
To pass validation in helm3, we need to correct RBAC in this chart.
```
control-plane-catalog/ingress-exporter
Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: ValidationError(ClusterRole.metadata): unknown field "rules" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
```