### PR TITLE
Increase memory limit to 100Mi

### DIFF
--- a/helm/ingress-exporter/templates/deployment.yaml
+++ b/helm/ingress-exporter/templates/deployment.yaml
@@ -50,10 +50,10 @@ spec:
         resources:
           requests:
             cpu: 100m
-            memory: 50Mi
+            memory: 100Mi
           limits:
             cpu: 100m
-            memory: 50Mi
+            memory: 100Mi
         ports:
           - name: http
             containerPort: 8000


### PR DESCRIPTION
Seems like `ingress-exporter` can sometimes need more than 50Mi memory. Looking at different installations - it spikes to `49Mi` on `buffalo` and to its full limit on `anubis`. Since `anubis` is one of the busiest installations, I have a feeling that this has something to do with this PM: https://github.com/giantswarm/giantswarm/issues/16222.