### PR TITLE
Check endpoint connections in separate goroutines

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/giantswarm/operatorkit/v2 v2.0.2
 	github.com/prometheus/client_golang v1.10.0
 	github.com/spf13/viper v1.7.1
-	golang.org/x/sync v0.0.0-20201207232520-09787c993a3a
 	k8s.io/api v0.18.19
 	k8s.io/apimachinery v0.18.19
 	k8s.io/client-go v0.18.19

--- a/service/collector/collector.go
+++ b/service/collector/collector.go
@@ -24,7 +24,7 @@ const (
 
 const (
 	maxIdleConnection = 5
-	maxTimeoutSec     = 5
+	maxTimeoutSec     = 3
 
 	ingressCheckSuccessful = 1
 	ingressCheckFailure    = 0

--- a/service/collector/collector.go
+++ b/service/collector/collector.go
@@ -25,6 +25,7 @@ const (
 const (
 	maxIdleConnection = 5
 	maxTimeoutSec     = 3
+	maxGoroutines     = 30
 
 	ingressCheckSuccessful = 1
 	ingressCheckFailure    = 0

--- a/service/collector/endpoint.go
+++ b/service/collector/endpoint.go
@@ -9,9 +9,8 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"sync"
 	"time"
-
-	"golang.org/x/sync/errgroup"
 
 	"github.com/giantswarm/apiextensions/v2/pkg/apis/application/v1alpha1"
 	"github.com/giantswarm/apiextensions/v2/pkg/clientset/versioned"
@@ -100,7 +99,7 @@ func (e *Endpoint) Collect(ch chan<- prometheus.Metric) error {
 		return microerror.Mask(err)
 	}
 
-	g := &errgroup.Group{}
+	wg := sync.WaitGroup{}
 
 	for _, kvmConfig := range kvmConfigs.Items {
 		if kvmConfig.DeletionTimestamp != nil {
@@ -117,17 +116,23 @@ func (e *Endpoint) Collect(ch chan<- prometheus.Metric) error {
 		if !isNginxIngressControllerInstalled(appList) {
 			// When nginx ingress controller is not deployed, worker ports are not open so there is no need to check for connectivity
 			e.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("skipping cluster %#q since it doesn't have %#q installed", kvmConfig.Spec.Cluster.ID, nginxIngressControllerAppName))
+
 			continue
 		}
 
-		g.Go(func() error {
-			endpoint, err := e.k8sClient.CoreV1().Endpoints(clusterID).Get(ctx, workerEndpoint, getOpts)
-			if err != nil {
-				return microerror.Mask(err)
-			}
+		endpoint, err := e.k8sClient.CoreV1().Endpoints(clusterID).Get(ctx, workerEndpoint, getOpts)
+		if err != nil {
+			return microerror.Mask(err)
+		}
 
-			ipList := getEndpointIps(endpoint)
-			for _, ip := range ipList {
+		ipList := getEndpointIps(endpoint)
+
+		for _, ip := range ipList {
+			wg.Add(1)
+
+			go func(ip string, wg *sync.WaitGroup) {
+				defer wg.Done()
+
 				ingressCheckState, proxyProtocol := e.ingressEndpointUp(ip, ingressSchemeHttp, ingressPortHttp)
 
 				// send ingress endpoint status metric
@@ -140,15 +145,11 @@ func (e *Endpoint) Collect(ch chan<- prometheus.Metric) error {
 					ingressSchemeHttp,
 					proxyProtocol,
 				)
-			}
-			return nil
-		})
+			}(ip, &wg)
+		}
 	}
 
-	err = g.Wait()
-	if err != nil {
-		return microerror.Mask(err)
-	}
+	wg.Wait()
 
 	return nil
 }


### PR DESCRIPTION
And decrease timeout to 3s. Even on busy installations like `anubis` it doesn't take more than 1-2ms to check an IP.

Towards https://github.com/giantswarm/giantswarm/issues/16222