### PR TITLE
Do not install PSP if apiVersion not available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Do not install PodSecurityPolicy if api not available.
+
 ## [1.1.13] - 2023-06-19
 
 ### Changed

--- a/helm/ingress-exporter/templates/psp.yaml
+++ b/helm/ingress-exporter/templates/psp.yaml
@@ -1,3 +1,4 @@
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1" }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -26,3 +27,4 @@ spec:
   hostNetwork: false
   hostIPC: false
   hostPID: false
+{{- end }}


### PR DESCRIPTION
This PR changes the helm templates to not install PodSecurityPolicies if their apiVersion is not available.

Towards giantswarm/giantswarm#23400